### PR TITLE
Add cross-browser table export extension

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,365 @@
+const browserApi = typeof browser !== 'undefined' ? browser : chrome;
+
+async function getState() {
+  const data = await browserApi.storage.local.get({ tables: [] });
+  return data;
+}
+
+async function setState(state) {
+  await browserApi.storage.local.set(state);
+}
+
+function normalizeUrlInfo(urlString) {
+  try {
+    const url = new URL(urlString);
+    return {
+      origin: url.origin,
+      pathname: url.pathname,
+    };
+  } catch (error) {
+    return null;
+  }
+}
+
+function ensureTableDefaults(table, sourceUrl) {
+  const normalized = normalizeUrlInfo(sourceUrl || table.urlTemplate || table.page?.origin + table.page?.pathname || '');
+  return {
+    id: table.id,
+    name: table.name,
+    urlTemplate: table.urlTemplate || sourceUrl || '',
+    page: table.page || normalized || { origin: '', pathname: '' },
+    tableSelector: table.tableSelector || '',
+    dataSection: table.dataSection || 'tbody',
+    columns: table.columns || [],
+  };
+}
+
+async function getTables() {
+  const { tables } = await getState();
+  return tables.map((table) => ensureTableDefaults(table));
+}
+
+async function saveTables(tables) {
+  await setState({ tables });
+}
+
+function findTableIndex(tables, tableId) {
+  return tables.findIndex((table) => table.id === tableId);
+}
+
+function createId(prefix) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function handleGetTablesForUrl(message) {
+  const tables = await getTables();
+  const { origin, pathname } = normalizeUrlInfo(message.url) || {};
+  return tables.filter((table) => {
+    if (!origin || !pathname) {
+      return false;
+    }
+    if (!table.page) {
+      return false;
+    }
+    return table.page.origin === origin && table.page.pathname === pathname;
+  });
+}
+
+async function handleCreateTable(message) {
+  const tables = await getTables();
+  const id = createId('table');
+  const normalized = normalizeUrlInfo(message.sourceUrl);
+  const table = ensureTableDefaults(
+    {
+      id,
+      name: message.name || `Table ${tables.length + 1}`,
+      urlTemplate: message.sourceUrl || '',
+      page: normalized || { origin: '', pathname: '' },
+      tableSelector: message.tableSelector || '',
+      dataSection: message.dataSection || 'tbody',
+      columns: [],
+    },
+    message.sourceUrl,
+  );
+  tables.push(table);
+  await saveTables(tables);
+  return table;
+}
+
+async function handleSaveColumn(message) {
+  const tables = await getTables();
+  const index = findTableIndex(tables, message.tableId);
+  if (index === -1) {
+    throw new Error('Table not found');
+  }
+  const table = tables[index];
+  const column = {
+    id: message.column.id || createId('col'),
+    name: message.column.name,
+    columnIndex: message.column.columnIndex,
+    sampleCellSelector: message.column.sampleCellSelector,
+    sampleRowIndex: message.column.sampleRowIndex,
+    section: message.column.section || 'tbody',
+  };
+  table.tableSelector = message.tableSelector || table.tableSelector;
+  table.dataSection = message.dataSection || table.dataSection || 'tbody';
+
+  const existingIndex = table.columns.findIndex((col) => col.id === column.id || col.name === column.name);
+  if (existingIndex !== -1) {
+    table.columns[existingIndex] = { ...table.columns[existingIndex], ...column };
+  } else {
+    table.columns.push(column);
+  }
+  tables[index] = table;
+  await saveTables(tables);
+  return table;
+}
+
+async function handleRemoveColumn(message) {
+  const tables = await getTables();
+  const index = findTableIndex(tables, message.tableId);
+  if (index === -1) {
+    throw new Error('Table not found');
+  }
+  const table = tables[index];
+  table.columns = table.columns.filter((col) => col.id !== message.columnId);
+  tables[index] = table;
+  await saveTables(tables);
+  return table;
+}
+
+async function handleUpdateTable(message) {
+  const tables = await getTables();
+  const index = findTableIndex(tables, message.table.id);
+  if (index === -1) {
+    throw new Error('Table not found');
+  }
+  const table = tables[index];
+  tables[index] = ensureTableDefaults({
+    ...table,
+    ...message.table,
+    page: normalizeUrlInfo(message.table.urlTemplate || table.urlTemplate) || table.page,
+  });
+  await saveTables(tables);
+  return tables[index];
+}
+
+async function handleDeleteTable(message) {
+  const tables = await getTables();
+  const filtered = tables.filter((table) => table.id !== message.tableId);
+  await saveTables(filtered);
+  return { tableId: message.tableId };
+}
+
+function csvEscape(value) {
+  if (value == null) {
+    return '';
+  }
+  const needsQuotes = /[",\n]/.test(value);
+  const escaped = value.replace(/"/g, '""');
+  return needsQuotes ? `"${escaped}"` : escaped;
+}
+
+function buildCsv(columns, rows) {
+  const header = ['Date', ...columns.map((col) => col.name)];
+  const lines = [header.map(csvEscape).join(',')];
+  for (const row of rows) {
+    const line = [row.__date || '', ...columns.map((col) => row[col.name] ?? '')];
+    lines.push(line.map((value) => csvEscape(String(value))).join(','));
+  }
+  return lines.join('\n');
+}
+
+async function waitForTabComplete(tabId) {
+  const tab = await browserApi.tabs.get(tabId);
+  if (tab.status === 'complete') {
+    return;
+  }
+  return new Promise((resolve) => {
+    const listener = (updatedTabId, info) => {
+      if (updatedTabId === tabId && info.status === 'complete') {
+        browserApi.tabs.onUpdated.removeListener(listener);
+        resolve();
+      }
+    };
+    browserApi.tabs.onUpdated.addListener(listener);
+  });
+}
+
+async function createTab(url) {
+  return new Promise((resolve) => {
+    browserApi.tabs.create({ url, active: false }, (tab) => resolve(tab));
+  });
+}
+
+async function closeTab(tabId) {
+  return new Promise((resolve) => {
+    browserApi.tabs.remove(tabId, () => resolve());
+  });
+}
+
+async function sendMessageToTab(tabId, payload) {
+  return new Promise((resolve, reject) => {
+    try {
+      browserApi.tabs.sendMessage(tabId, payload, (response) => {
+        const error = browserApi.runtime.lastError;
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(response);
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function buildUrlFromTemplate(template, dateValue, table) {
+  if (!template) {
+    return '';
+  }
+  if (template.includes('{{date}}')) {
+    const dateToken = encodeURIComponent(dateValue);
+    return template.replace(/\{\{date\}\}/g, dateToken);
+  }
+  let base = template;
+  if (!/^https?:/i.test(template)) {
+    const origin = table?.page?.origin || '';
+    if (!origin) {
+      return '';
+    }
+    base = `${origin.replace(/\/$/, '')}/${template.replace(/^\//, '')}`;
+  }
+  try {
+    const url = new URL(base);
+    url.searchParams.set('date', dateValue);
+    return url.toString();
+  } catch (error) {
+    return '';
+  }
+}
+
+async function downloadCsv(tableName, csv) {
+  const timestamp = new Date().toISOString().replace(/[:T]/g, '-').split('.')[0];
+  const filename = `${tableName || 'table'}-${timestamp}.csv`;
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  return new Promise((resolve) => {
+    browserApi.downloads.download({ url, filename }, () => {
+      URL.revokeObjectURL(url);
+      resolve();
+    });
+  });
+}
+
+async function exportTable(message) {
+  const tables = await getTables();
+  const table = tables.find((item) => item.id === message.tableId);
+  if (!table) {
+    throw new Error('Table not found');
+  }
+  if (!table.columns || table.columns.length === 0) {
+    throw new Error('Table has no columns defined');
+  }
+  const dates = (message.dates || []).filter(Boolean);
+  if (!dates.length) {
+    throw new Error('No dates provided');
+  }
+  const aggregated = [];
+  for (const date of dates) {
+    const url = buildUrlFromTemplate(table.urlTemplate, date, table);
+    if (!url) {
+      throw new Error('Table URL template is invalid');
+    }
+    const tab = await createTab(url);
+    await waitForTabComplete(tab.id);
+    let response;
+    try {
+      response = await sendMessageToTab(tab.id, {
+        type: 'PERFORM_SCRAPE',
+        table,
+        date,
+      });
+    } finally {
+      await closeTab(tab.id);
+    }
+    if (!response || response.error) {
+      throw new Error(response?.error || 'Unable to scrape table');
+    }
+    for (const row of response.rows) {
+      aggregated.push({ ...row, __date: date });
+    }
+  }
+  const csv = buildCsv(table.columns, aggregated);
+  await downloadCsv(table.name, csv);
+  if (browserApi.notifications) {
+    browserApi.notifications.create({
+      type: 'basic',
+      iconUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAPCAYAAADJViUEAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAKZJREFUeNpi/P//PwMlgImBQjDwZ2Bg+M/AwPCfgRFBxMAEI5gGiF7g4GAJEM0H4jLg3E8QHYh4D4g2E8QbYh4P8AZj1gYkApGoG4D4jLg/EcQfYgYF4B4nIgxF8j0MWYDEQJxF8nsT0A8jkYH4HxAdTHEDsT0D8nFgfgfED1McQOxPQPyKQMDIYw1iArElgPgeEmYg2E8QHYg6AsT2AzEqg/ExKDvD8T8QUXgk0EoGgFgQwAAAwBcvxjzoWJt6gAAAABJRU5ErkJggg==',
+      title: 'Eva Table Reactor',
+      message: `Export for ${table.name} completed (${dates.length} date${dates.length === 1 ? '' : 's'}).`,
+    });
+  }
+  return { status: 'completed' };
+}
+
+browserApi.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  (async () => {
+    try {
+      switch (message?.type) {
+        case 'GET_TABLES_FOR_URL':
+          sendResponse({ tables: await handleGetTablesForUrl(message) });
+          break;
+        case 'CREATE_TABLE':
+          sendResponse({ table: await handleCreateTable(message) });
+          break;
+        case 'SAVE_COLUMN':
+          sendResponse({ table: await handleSaveColumn(message) });
+          break;
+        case 'REMOVE_COLUMN':
+          sendResponse({ table: await handleRemoveColumn(message) });
+          break;
+        case 'UPDATE_TABLE':
+          sendResponse({ table: await handleUpdateTable(message) });
+          break;
+        case 'DELETE_TABLE':
+          await handleDeleteTable(message);
+          sendResponse({ success: true });
+          break;
+        case 'GET_ALL_TABLES':
+          sendResponse({ tables: await getTables() });
+          break;
+        case 'EXPORT_TABLE':
+          exportTable(message)
+            .then(() => {
+              // no-op; result handled via notification
+            })
+            .catch((error) => {
+              if (browserApi.notifications) {
+                browserApi.notifications.create({
+                  type: 'basic',
+                  iconUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAPCAYAAADJViUEAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAItJREFUeNpi/P//PwMlgImBQjDwZ2Bg+M/AwPCfgRFBxMAEI5gGiF7g4GAJEM0H4jLg3E8QHYh4D4g2E8QbYh4P8AZj1gYkApGoG4D4jLg/EcQfYgYF4B4nIgxF8j0MWYDEQJxF8nsT0A8jkYH4HxAdTHEDsT0D8nFgfgfED1McQOxPQPyKQMDIYw1iArElgPgeEmYg2E8QHYg6AsT2AzEqg/ExKDvD8T8QUXgk0EoGgFgQwAAAMB5yx8v5pWFBwAAAABJRU5ErkJggg==',
+                  title: 'Eva Table Reactor',
+                  message: error.message || 'Export failed.',
+                });
+              }
+            });
+          sendResponse({ status: 'started' });
+          break;
+        default:
+          sendResponse({ error: 'Unknown message type' });
+      }
+    } catch (error) {
+      sendResponse({ error: error.message || String(error) });
+    }
+  })();
+  return true;
+});
+
+browserApi.runtime.onInstalled.addListener(async () => {
+  const tables = await getTables();
+  if (!tables.length) {
+    await saveTables([]);
+  }
+});

--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -1,0 +1,468 @@
+const browserApi = window.browser ?? window.chrome;
+
+const state = {
+  tables: [],
+  selectedTableId: null,
+  currentSelection: null,
+  highlightedStored: new Set(),
+  currentHighlightedCell: null,
+  overlay: null,
+};
+
+function cssEscape(identifier) {
+  if (typeof CSS !== 'undefined' && CSS.escape) {
+    return CSS.escape(identifier);
+  }
+  return identifier.replace(/([\0-\x1F\x7F-\x9F!"#$%&'()*+,./:;<=>?@\[\]`{|}~])/g, '\\$1');
+}
+
+function buildSelector(element, stopAt) {
+  if (!element || element === stopAt) {
+    return '';
+  }
+  if (element.id) {
+    return `#${cssEscape(element.id)}`;
+  }
+  const segments = [];
+  let current = element;
+  while (current && current !== stopAt && current.nodeType === Node.ELEMENT_NODE) {
+    let segment = current.tagName.toLowerCase();
+    if (current.id) {
+      segment = `#${cssEscape(current.id)}`;
+      segments.unshift(segment);
+      break;
+    }
+    const siblingIndex = (() => {
+      let index = 1;
+      let sibling = current;
+      while ((sibling = sibling.previousElementSibling)) {
+        if (sibling.tagName === current.tagName) {
+          index += 1;
+        }
+      }
+      return index;
+    })();
+    segment += `:nth-of-type(${siblingIndex})`;
+    segments.unshift(segment);
+    current = current.parentElement;
+  }
+  return segments.join(' > ');
+}
+
+function uniqueSelector(element) {
+  if (!element) {
+    return '';
+  }
+  const root = document.body;
+  const selector = buildSelector(element, root);
+  if (selector) {
+    return selector;
+  }
+  return element.tagName.toLowerCase();
+}
+
+function sendMessage(payload) {
+  return new Promise((resolve) => {
+    browserApi.runtime.sendMessage(payload, (response) => {
+      resolve(response || {});
+    });
+  });
+}
+
+function clearStoredHighlights() {
+  for (const selector of state.highlightedStored) {
+    const element = document.querySelector(selector);
+    if (element) {
+      element.classList.remove('eva-table-reactor-stored');
+    }
+  }
+  state.highlightedStored.clear();
+}
+
+function highlightStoredColumns() {
+  clearStoredHighlights();
+  state.tables.forEach((table) => {
+    table.columns.forEach((column) => {
+      if (!column.sampleCellSelector) {
+        return;
+      }
+      const element = document.querySelector(column.sampleCellSelector);
+      if (element) {
+        element.classList.add('eva-table-reactor-stored');
+        state.highlightedStored.add(column.sampleCellSelector);
+      }
+    });
+  });
+}
+
+function highlightSelectedCell(element) {
+  if (state.currentHighlightedCell && state.currentHighlightedCell !== element) {
+    state.currentHighlightedCell.classList.remove('eva-table-reactor-selected');
+  }
+  state.currentHighlightedCell = element || null;
+  if (state.currentHighlightedCell) {
+    state.currentHighlightedCell.classList.add('eva-table-reactor-selected');
+  }
+}
+
+function getSelectedTable() {
+  if (!state.selectedTableId) {
+    return null;
+  }
+  return state.tables.find((table) => table.id === state.selectedTableId) || null;
+}
+
+function ensureOverlay() {
+  if (state.overlay) {
+    return state.overlay;
+  }
+  const overlay = document.createElement('div');
+  overlay.className = 'table-reactor-overlay';
+  overlay.innerHTML = `
+    <header>
+      <span>Eva Table Reactor</span>
+      <button type="button" class="toggle-visibility" title="Hide">×</button>
+    </header>
+    <div class="overlay-body">
+      <div class="field-row">
+        <label style="flex:1">
+          <span>Output table</span>
+          <select class="table-select"></select>
+        </label>
+        <button type="button" class="secondary create-table">New</button>
+      </div>
+      <div class="info-block instructions">Hold <kbd>Alt</kbd> and click a table cell to capture it.</div>
+      <div class="info-block selection-preview">
+        <div><strong>Cell value:</strong> <span class="cell-value">None</span></div>
+        <div><strong>Column index:</strong> <span class="cell-index">-</span></div>
+        <div><strong>Table selector:</strong> <code class="table-selector">n/a</code></div>
+        <div><strong>Cell selector:</strong> <code class="cell-selector">n/a</code></div>
+      </div>
+      <label>
+        <span>Column name</span>
+        <input type="text" class="column-name" placeholder="e.g. Close price" />
+      </label>
+      <div class="field-row">
+        <button type="button" class="primary save-column" disabled>Save column</button>
+        <span class="status-message"></span>
+      </div>
+      <div>
+        <strong>Columns</strong>
+        <ul class="column-list"></ul>
+      </div>
+    </div>
+  `;
+  overlay.querySelector('.toggle-visibility').addEventListener('click', () => {
+    overlay.classList.add('hidden');
+  });
+  overlay.addEventListener('mouseenter', () => {
+    overlay.dataset.mouseInside = 'true';
+  });
+  overlay.addEventListener('mouseleave', () => {
+    overlay.dataset.mouseInside = 'false';
+  });
+  overlay.dataset.mouseInside = 'false';
+  document.body.appendChild(overlay);
+  state.overlay = overlay;
+  return overlay;
+}
+
+function showOverlay() {
+  const overlay = ensureOverlay();
+  overlay.classList.remove('hidden');
+}
+
+function setStatus(message) {
+  const overlay = ensureOverlay();
+  const status = overlay.querySelector('.status-message');
+  if (status) {
+    status.textContent = message || '';
+  }
+}
+
+function renderTables() {
+  const overlay = ensureOverlay();
+  const select = overlay.querySelector('.table-select');
+  select.innerHTML = '';
+  state.tables.forEach((table) => {
+    const option = document.createElement('option');
+    option.value = table.id;
+    option.textContent = table.name;
+    select.appendChild(option);
+  });
+  if (!state.selectedTableId && state.tables.length) {
+    state.selectedTableId = state.tables[0].id;
+  }
+  if (state.selectedTableId) {
+    select.value = state.selectedTableId;
+  }
+  select.onchange = () => {
+    state.selectedTableId = select.value;
+    updateColumnsList();
+    highlightStoredColumns();
+  };
+}
+
+function updateSelectionPreview(selection) {
+  const overlay = ensureOverlay();
+  overlay.querySelector('.cell-value').textContent = selection ? selection.value : 'None';
+  overlay.querySelector('.cell-index').textContent = selection ? `${selection.columnIndex}` : '-';
+  overlay.querySelector('.table-selector').textContent = selection ? selection.tableSelector : 'n/a';
+  overlay.querySelector('.cell-selector').textContent = selection ? selection.sampleCellSelector : 'n/a';
+  const saveButton = overlay.querySelector('.save-column');
+  saveButton.disabled = !selection || !overlay.querySelector('.column-name').value.trim() || !state.selectedTableId;
+}
+
+function updateColumnsList() {
+  const overlay = ensureOverlay();
+  const list = overlay.querySelector('.column-list');
+  list.innerHTML = '';
+  const table = getSelectedTable();
+  if (!table) {
+    const empty = document.createElement('li');
+    empty.textContent = 'No table selected.';
+    list.appendChild(empty);
+    return;
+  }
+  if (!table.columns.length) {
+    const empty = document.createElement('li');
+    empty.textContent = 'No columns yet. Click a cell to start mapping.';
+    list.appendChild(empty);
+    return;
+  }
+  table.columns.forEach((column) => {
+    const item = document.createElement('li');
+    const label = document.createElement('span');
+    label.textContent = column.name;
+    const actions = document.createElement('button');
+    actions.className = 'secondary';
+    actions.textContent = 'Remove';
+    actions.addEventListener('click', async () => {
+      await sendMessage({
+        type: 'REMOVE_COLUMN',
+        tableId: table.id,
+        columnId: column.id,
+      });
+      await loadTables();
+      setStatus(`Column “${column.name}” removed.`);
+    });
+    item.appendChild(label);
+    item.appendChild(actions);
+    list.appendChild(item);
+  });
+}
+
+async function loadTables() {
+  const response = await sendMessage({
+    type: 'GET_TABLES_FOR_URL',
+    url: window.location.href,
+  });
+  state.tables = response.tables || [];
+  if (!state.selectedTableId || !state.tables.some((table) => table.id === state.selectedTableId)) {
+    state.selectedTableId = state.tables[0]?.id || null;
+  }
+  renderTables();
+  updateColumnsList();
+  highlightStoredColumns();
+}
+
+async function handleCreateTable() {
+  const name = window.prompt('Name for the new output table:');
+  if (!name) {
+    return;
+  }
+  const response = await sendMessage({
+    type: 'CREATE_TABLE',
+    name,
+    sourceUrl: window.location.href,
+  });
+  if (response?.table) {
+    state.selectedTableId = response.table.id;
+    await loadTables();
+    setStatus(`Created table “${response.table.name}”.`);
+  }
+}
+
+async function saveCurrentSelection() {
+  const table = getSelectedTable();
+  const overlay = ensureOverlay();
+  if (!table) {
+    setStatus('Select or create an output table first.');
+    return;
+  }
+  const nameInput = overlay.querySelector('.column-name');
+  const columnName = nameInput.value.trim();
+  if (!columnName) {
+    setStatus('Provide a column name before saving.');
+    return;
+  }
+  const selection = state.currentSelection;
+  if (!selection) {
+    setStatus('Click a table cell to capture it.');
+    return;
+  }
+  const response = await sendMessage({
+    type: 'SAVE_COLUMN',
+    tableId: table.id,
+    tableSelector: selection.tableSelector,
+    dataSection: selection.section,
+    column: {
+      name: columnName,
+      columnIndex: selection.columnIndex,
+      sampleCellSelector: selection.sampleCellSelector,
+      sampleRowIndex: selection.sampleRowIndex,
+      section: selection.section,
+    },
+  });
+  if (response?.table) {
+    nameInput.value = '';
+    state.currentSelection = null;
+    highlightSelectedCell(null);
+    updateSelectionPreview(null);
+    await loadTables();
+    setStatus(`Column “${columnName}” saved.`);
+  }
+}
+
+function captureCell(event) {
+  const overlay = ensureOverlay();
+  if (overlay.dataset.mouseInside === 'true') {
+    return;
+  }
+  if (!event.altKey) {
+    return;
+  }
+  const cell = event.target.closest('td,th');
+  if (!cell || cell.closest('.table-reactor-overlay')) {
+    return;
+  }
+  const tableElement = cell.closest('table');
+  if (!tableElement) {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  showOverlay();
+  const row = cell.closest('tr');
+  const sectionElement = cell.closest('tbody, thead, tfoot');
+  const section = sectionElement ? sectionElement.tagName.toLowerCase() : 'tbody';
+  const sectionRows = sectionElement
+    ? Array.from(sectionElement.querySelectorAll('tr'))
+    : Array.from(tableElement.querySelectorAll('tr'));
+  const sampleRowIndex = sectionRows.indexOf(row);
+  const columnIndex = (() => {
+    const cells = Array.from(row.querySelectorAll('th,td'));
+    return cells.indexOf(cell);
+  })();
+  const selection = {
+    value: cell.innerText.trim(),
+    columnIndex,
+    tableSelector: uniqueSelector(tableElement),
+    sampleCellSelector: uniqueSelector(cell),
+    sampleRowIndex: sampleRowIndex >= 0 ? sampleRowIndex : 0,
+    section,
+  };
+  state.currentSelection = selection;
+  highlightSelectedCell(cell);
+  updateSelectionPreview(selection);
+  setStatus(section === 'thead' ? 'Warning: header rows are ignored during export.' : 'Cell captured. Provide a column name and save.');
+  const saveButton = overlay.querySelector('.save-column');
+  saveButton.disabled = !overlay.querySelector('.column-name').value.trim();
+}
+
+function attachOverlayHandlers() {
+  const overlay = ensureOverlay();
+  overlay.querySelector('.create-table').addEventListener('click', handleCreateTable);
+  overlay.querySelector('.save-column').addEventListener('click', saveCurrentSelection);
+  overlay.querySelector('.column-name').addEventListener('input', (event) => {
+    const hasValue = event.target.value.trim().length > 0;
+    const overlayElement = ensureOverlay();
+    overlayElement.querySelector('.save-column').disabled = !hasValue || !state.currentSelection;
+  });
+}
+
+function initializeOverlay() {
+  ensureOverlay();
+  attachOverlayHandlers();
+  loadTables();
+  setStatus('Hold Alt and click a cell to capture it.');
+}
+
+function scrapeTable(tableConfig) {
+  if (!tableConfig?.tableSelector) {
+    return { error: 'Table selector missing in configuration.' };
+  }
+  const tableElement = document.querySelector(tableConfig.tableSelector);
+  if (!tableElement) {
+    return { error: `Table not found for selector ${tableConfig.tableSelector}` };
+  }
+  const section = tableConfig.dataSection || 'tbody';
+  let rows = [];
+  if (section !== 'table') {
+    const containers = tableElement.querySelectorAll(section);
+    containers.forEach((container) => {
+      if (container.matches('tbody, thead, tfoot')) {
+        rows = rows.concat(Array.from(container.querySelectorAll('tr')));
+      }
+    });
+  }
+  if (!rows.length) {
+    rows = Array.from(tableElement.querySelectorAll('tr'));
+  }
+  rows = rows.filter((row) => {
+    if (!row.closest('table') || row.closest('table') !== tableElement) {
+      return false;
+    }
+    if (row.closest('thead')) {
+      return false;
+    }
+    const cells = row.querySelectorAll('td,th');
+    return cells.length > 0;
+  });
+  const minSampleIndex = Math.min(
+    ...tableConfig.columns.map((column) => (typeof column.sampleRowIndex === 'number' ? column.sampleRowIndex : 0)),
+  );
+  const bodyRows = rows.slice(minSampleIndex >= 0 ? minSampleIndex : 0);
+  const records = bodyRows.map((row) => {
+    const cells = Array.from(row.querySelectorAll('td,th'));
+    const record = {};
+    tableConfig.columns.forEach((column) => {
+      const cell = cells[column.columnIndex];
+      record[column.name] = cell ? cell.innerText.trim() : '';
+    });
+    return record;
+  });
+  return { rows: records };
+}
+
+function initialize() {
+  initializeOverlay();
+  document.addEventListener(
+    'click',
+    (event) => {
+      captureCell(event);
+    },
+    true,
+  );
+  browserApi.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message?.type === 'PERFORM_SCRAPE') {
+      const result = scrapeTable(message.table);
+      sendResponse(result);
+      return true;
+    }
+    return undefined;
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initialize);
+} else {
+  initialize();
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && state.overlay && !state.overlay.classList.contains('hidden')) {
+    state.overlay.classList.add('hidden');
+  }
+});
+

--- a/extension/contentStyles.css
+++ b/extension/contentStyles.css
@@ -1,0 +1,165 @@
+.table-reactor-overlay {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  width: 320px;
+  max-height: 90vh;
+  background: rgba(13, 17, 23, 0.95);
+  color: #f5f5f5;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 13px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  border-radius: 12px;
+  z-index: 2147483647;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.table-reactor-overlay.hidden {
+  display: none;
+}
+
+.table-reactor-overlay header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: rgba(33, 150, 243, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+}
+
+.table-reactor-overlay header button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.table-reactor-overlay .overlay-body {
+  padding: 12px 14px 16px;
+  overflow-y: auto;
+  display: grid;
+  gap: 14px;
+}
+
+.table-reactor-overlay label {
+  display: grid;
+  gap: 6px;
+  font-weight: 500;
+}
+
+.table-reactor-overlay select,
+.table-reactor-overlay input,
+.table-reactor-overlay textarea,
+.table-reactor-overlay button {
+  font: inherit;
+}
+
+.table-reactor-overlay select,
+.table-reactor-overlay input,
+.table-reactor-overlay textarea {
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(9, 12, 16, 0.8);
+  color: inherit;
+}
+
+.table-reactor-overlay button.primary {
+  background: #2196f3;
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.table-reactor-overlay button.secondary {
+  background: transparent;
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.table-reactor-overlay .field-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.table-reactor-overlay .field-row button {
+  white-space: nowrap;
+}
+
+.table-reactor-overlay .info-block {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  padding: 8px;
+  line-height: 1.4;
+}
+
+.table-reactor-overlay kbd {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  font-size: 11px;
+  background: rgba(9, 12, 16, 0.8);
+}
+
+.table-reactor-overlay code {
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.table-reactor-overlay ul.column-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.table-reactor-overlay ul.column-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 8px;
+  padding: 6px 8px;
+}
+
+.table-reactor-overlay .status-message {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.eva-table-reactor-stored {
+  outline: 2px solid rgba(33, 150, 243, 0.8) !important;
+  outline-offset: 2px !important;
+  position: relative;
+}
+
+.eva-table-reactor-stored::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-top: 10px solid rgba(33, 150, 243, 0.8);
+  border-left: 10px solid transparent;
+}
+
+.eva-table-reactor-selected {
+  outline: 3px solid #ff9800 !important;
+  outline-offset: 2px !important;
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,41 @@
+{
+  "manifest_version": 3,
+  "name": "Eva Table Reactor",
+  "description": "Capture tabular data from arbitrary web pages, map columns, and export CSV batches across dates.",
+  "version": "0.1.0",
+  "action": {
+    "default_title": "Eva Table Reactor",
+    "default_popup": "popup.html"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "permissions": [
+    "storage",
+    "tabs",
+    "scripting",
+    "downloads",
+    "notifications"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"],
+      "css": ["contentStyles.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "eva-table-reactor@example.com",
+      "strict_min_version": "109.0"
+    }
+  }
+}

--- a/extension/options.css
+++ b/extension/options.css
@@ -1,0 +1,143 @@
+:root {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #020617;
+  color: #e2e8f0;
+}
+
+.page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+  display: grid;
+  gap: 24px;
+}
+
+.page > header {
+  display: grid;
+  gap: 8px;
+}
+
+.page > header h1 {
+  margin: 0;
+  font-size: 28px;
+}
+
+.page > header p {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.table-card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: 20px;
+  display: grid;
+  gap: 16px;
+}
+
+.table-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.table-card header input.table-name {
+  flex: 1;
+  padding: 10px 12px;
+  font-size: 18px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(2, 6, 23, 0.8);
+  color: inherit;
+}
+
+.table-card .table-meta {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.table-card label {
+  display: grid;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.table-card input,
+.table-card select {
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(2, 6, 23, 0.6);
+  color: inherit;
+  font: inherit;
+}
+
+.columns h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.column-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.column-list li {
+  padding: 8px 10px;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+}
+
+.column-list li code {
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
+  color: #38bdf8;
+}
+
+.table-card footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.table-card footer button {
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.table-card footer .save {
+  background: #22d3ee;
+  color: #0f172a;
+}
+
+.table-card footer .delete {
+  background: rgba(239, 68, 68, 0.1);
+  color: #fca5a5;
+}
+
+.empty {
+  text-align: center;
+  padding: 80px 0;
+  color: #64748b;
+}
+
+.empty p {
+  margin: 0;
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Eva Table Reactor – Tables</title>
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <main class="page">
+      <header>
+        <h1>Eva Table Reactor</h1>
+        <p>Manage configured tables, URL templates, and mapped columns.</p>
+      </header>
+      <section id="tables"></section>
+      <section class="empty" id="emptyState" hidden>
+        <p>No tables defined yet. Visit a page with a table, select cells using the overlay, and save a configuration.</p>
+      </section>
+    </main>
+    <template id="tableTemplate">
+      <article class="table-card">
+        <header>
+          <input class="table-name" type="text" />
+          <div class="table-meta">
+            <span class="page-url"></span>
+          </div>
+        </header>
+        <label>
+          <span>URL template (use <code>{{date}}</code> placeholder for export)</span>
+          <input class="url-template" type="text" />
+        </label>
+        <label>
+          <span>Data section</span>
+          <select class="data-section">
+            <option value="tbody">tbody (default)</option>
+            <option value="table">Entire table</option>
+            <option value="thead">thead</option>
+            <option value="tfoot">tfoot</option>
+          </select>
+        </label>
+        <section class="columns">
+          <h2>Columns</h2>
+          <ul class="column-list"></ul>
+        </section>
+        <footer>
+          <button class="save">Save changes</button>
+          <button class="delete">Delete table</button>
+        </footer>
+      </article>
+    </template>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,111 @@
+const browserApi = window.browser ?? window.chrome;
+
+function sendMessage(payload) {
+  return new Promise((resolve) => {
+    browserApi.runtime.sendMessage(payload, (response) => {
+      resolve(response || {});
+    });
+  });
+}
+
+function formatPageUrl(table) {
+  if (!table?.page) {
+    return '—';
+  }
+  return `${table.page.origin}${table.page.pathname}`;
+}
+
+function renderColumns(list, table) {
+  list.innerHTML = '';
+  if (!table.columns || !table.columns.length) {
+    const item = document.createElement('li');
+    item.textContent = 'No columns mapped yet.';
+    list.appendChild(item);
+    return;
+  }
+  table.columns.forEach((column) => {
+    const item = document.createElement('li');
+    const label = document.createElement('span');
+    label.textContent = `${column.name} (index ${column.columnIndex})`;
+    const selector = document.createElement('code');
+    selector.textContent = column.sampleCellSelector || '';
+    item.appendChild(label);
+    item.appendChild(selector);
+    list.appendChild(item);
+  });
+}
+
+function createTableCard(table) {
+  const template = document.getElementById('tableTemplate');
+  const node = template.content.firstElementChild.cloneNode(true);
+  const nameInput = node.querySelector('.table-name');
+  const urlInput = node.querySelector('.url-template');
+  const sectionSelect = node.querySelector('.data-section');
+  const meta = node.querySelector('.page-url');
+  const columnsList = node.querySelector('.column-list');
+  const saveButton = node.querySelector('.save');
+  const deleteButton = node.querySelector('.delete');
+
+  nameInput.value = table.name || '';
+  urlInput.value = table.urlTemplate || '';
+  sectionSelect.value = table.dataSection || 'tbody';
+  meta.textContent = formatPageUrl(table);
+  renderColumns(columnsList, table);
+
+  saveButton.addEventListener('click', async () => {
+    saveButton.disabled = true;
+    const initialText = saveButton.textContent;
+    saveButton.textContent = 'Saving…';
+    const updated = {
+      ...table,
+      name: nameInput.value.trim() || table.name,
+      urlTemplate: urlInput.value.trim(),
+      dataSection: sectionSelect.value,
+    };
+    const response = await sendMessage({ type: 'UPDATE_TABLE', table: updated });
+    if (response.error) {
+      saveButton.textContent = 'Failed';
+    } else {
+      saveButton.textContent = 'Saved';
+      Object.assign(table, response.table || updated);
+      renderColumns(columnsList, table);
+      meta.textContent = formatPageUrl(table);
+    }
+    setTimeout(() => {
+      saveButton.disabled = false;
+      saveButton.textContent = initialText;
+    }, 1000);
+  });
+
+  deleteButton.addEventListener('click', async () => {
+    if (!window.confirm(`Delete table “${table.name}”? This cannot be undone.`)) {
+      return;
+    }
+    deleteButton.disabled = true;
+    deleteButton.textContent = 'Deleting…';
+    await sendMessage({ type: 'DELETE_TABLE', tableId: table.id });
+    await loadTables();
+  });
+
+  return node;
+}
+
+async function loadTables() {
+  const container = document.getElementById('tables');
+  const empty = document.getElementById('emptyState');
+  container.innerHTML = '';
+  const response = await sendMessage({ type: 'GET_ALL_TABLES' });
+  const tables = response.tables || [];
+  if (!tables.length) {
+    empty.hidden = false;
+    return;
+  }
+  empty.hidden = true;
+  tables.forEach((table) => {
+    container.appendChild(createTableCard(table));
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadTables();
+});

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,0 +1,71 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0f172a;
+  color: #f8fafc;
+  min-width: 280px;
+}
+
+.popup {
+  padding: 16px;
+  display: grid;
+  gap: 14px;
+}
+
+h1 {
+  font-size: 16px;
+  margin: 0;
+}
+
+label {
+  display: grid;
+  gap: 6px;
+  font-size: 13px;
+}
+
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+select,
+textarea {
+  padding: 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+button {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: none;
+  background: #38bdf8;
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.actions a {
+  color: #a855f7;
+  font-size: 12px;
+}
+
+.status {
+  font-size: 12px;
+  min-height: 16px;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Eva Table Reactor</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main class="popup">
+      <h1>Eva Table Reactor</h1>
+      <section>
+        <label>
+          <span>Output table</span>
+          <select id="tableSelect"></select>
+        </label>
+      </section>
+      <section>
+        <label>
+          <span>Dates (one per line)</span>
+          <textarea id="dateInput" rows="4" placeholder="2024-01-01\n2024-01-02"></textarea>
+        </label>
+      </section>
+      <section class="actions">
+        <button id="exportButton" disabled>Export CSV</button>
+        <a href="#" id="manageLink">Manage tables</a>
+      </section>
+      <p class="status" id="status"></p>
+    </main>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,94 @@
+const browserApi = window.browser ?? window.chrome;
+
+function sendMessage(payload) {
+  return new Promise((resolve) => {
+    browserApi.runtime.sendMessage(payload, (response) => {
+      resolve(response || {});
+    });
+  });
+}
+
+function setStatus(message) {
+  const status = document.getElementById('status');
+  if (status) {
+    status.textContent = message || '';
+  }
+}
+
+function parseDates(value) {
+  return value
+    .split(/\r?\n|,/) // split on newline or comma
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+async function loadTables() {
+  const select = document.getElementById('tableSelect');
+  select.innerHTML = '';
+  const response = await sendMessage({ type: 'GET_ALL_TABLES' });
+  const tables = response.tables || [];
+  tables.forEach((table) => {
+    const option = document.createElement('option');
+    option.value = table.id;
+    option.textContent = table.name;
+    select.appendChild(option);
+  });
+  const exportButton = document.getElementById('exportButton');
+  const dates = parseDates(document.getElementById('dateInput').value);
+  exportButton.disabled = tables.length === 0 || !select.value || !dates.length;
+  if (!tables.length) {
+    setStatus('Create a table from a page before exporting.');
+  } else {
+    setStatus('');
+  }
+}
+
+async function handleExport() {
+  const select = document.getElementById('tableSelect');
+  const tableId = select.value;
+  const dates = parseDates(document.getElementById('dateInput').value);
+  if (!tableId) {
+    setStatus('Choose an output table first.');
+    return;
+  }
+  if (!dates.length) {
+    setStatus('Provide at least one date.');
+    return;
+  }
+  setStatus('Starting export in background…');
+  const response = await sendMessage({
+    type: 'EXPORT_TABLE',
+    tableId,
+    dates,
+  });
+  if (response.error) {
+    setStatus(`Export failed: ${response.error}`);
+  } else {
+    setStatus('Export started. You will receive a download when finished.');
+  }
+}
+
+function initialize() {
+  loadTables();
+  document.getElementById('dateInput').addEventListener('input', () => {
+    const dates = parseDates(document.getElementById('dateInput').value);
+    const exportButton = document.getElementById('exportButton');
+    exportButton.disabled = !document.getElementById('tableSelect').value || !dates.length;
+  });
+  document.getElementById('tableSelect').addEventListener('change', () => {
+    const dates = parseDates(document.getElementById('dateInput').value);
+    const exportButton = document.getElementById('exportButton');
+    exportButton.disabled = !document.getElementById('tableSelect').value || !dates.length;
+  });
+  document.getElementById('exportButton').addEventListener('click', handleExport);
+  document.getElementById('manageLink').addEventListener('click', (event) => {
+    event.preventDefault();
+    if (browserApi.runtime.openOptionsPage) {
+      browserApi.runtime.openOptionsPage();
+    } else {
+      window.open(browserApi.runtime.getURL('options.html'));
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initialize);


### PR DESCRIPTION
## Summary
- add a browser-extension scaffold with a manifest and service worker that orchestrate storage, CSV export, and notifications
- provide a content script overlay to map table columns with Alt+click selection and persisted highlighting
- add popup and options UIs for triggering multi-date exports and maintaining URL templates

## Testing
- not run (manual testing required)

------
https://chatgpt.com/codex/tasks/task_e_68e378e1dcf88326afb1cde1a6357bb5