### PR TITLE
Add column source metadata and improve guidance

### DIFF
--- a/extension/contentStyles.css
+++ b/extension/contentStyles.css
@@ -137,6 +137,22 @@
   padding: 6px 8px;
 }
 
+.table-reactor-overlay ul.column-list li .column-info {
+  display: grid;
+  gap: 4px;
+  max-width: 70%;
+}
+
+.table-reactor-overlay ul.column-list li .column-label {
+  font-weight: 600;
+}
+
+.table-reactor-overlay ul.column-list li .column-meta {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.6);
+  word-break: break-all;
+}
+
 .table-reactor-overlay .status-message {
   font-size: 12px;
   color: rgba(255, 255, 255, 0.7);
@@ -157,6 +173,23 @@
   height: 0;
   border-top: 10px solid rgba(33, 150, 243, 0.8);
   border-left: 10px solid transparent;
+}
+
+.eva-table-reactor-stored[data-eva-table-reactor-column]:hover::before {
+  content: attr(data-eva-table-reactor-column);
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background: rgba(13, 17, 23, 0.95);
+  color: #f5f5f5;
+  padding: 6px 8px;
+  border-radius: 6px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+  white-space: pre;
+  font-size: 12px;
+  z-index: 2147483647;
+  pointer-events: none;
 }
 
 .eva-table-reactor-selected {

--- a/extension/options.css
+++ b/extension/options.css
@@ -102,6 +102,22 @@ body {
   font-size: 13px;
 }
 
+.column-list li .column-info {
+  display: grid;
+  gap: 4px;
+  max-width: 70%;
+}
+
+.column-list li .column-title {
+  font-weight: 600;
+}
+
+.column-list li .column-source {
+  font-size: 11px;
+  color: #94a3b8;
+  word-break: break-all;
+}
+
 .column-list li code {
   font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace;
   font-size: 12px;

--- a/extension/options.js
+++ b/extension/options.js
@@ -25,11 +25,24 @@ function renderColumns(list, table) {
   }
   table.columns.forEach((column) => {
     const item = document.createElement('li');
-    const label = document.createElement('span');
-    label.textContent = `${column.name} (index ${column.columnIndex})`;
+    const info = document.createElement('div');
+    info.className = 'column-info';
+
+    const title = document.createElement('span');
+    title.className = 'column-title';
+    title.textContent = `${column.name} (index ${column.columnIndex})`;
+
+    const source = document.createElement('span');
+    source.className = 'column-source';
+    source.textContent = column.sourceUrl || '—';
+
     const selector = document.createElement('code');
     selector.textContent = column.sampleCellSelector || '';
-    item.appendChild(label);
+
+    info.appendChild(title);
+    info.appendChild(source);
+
+    item.appendChild(info);
     item.appendChild(selector);
     list.appendChild(item);
   });

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -17,6 +17,11 @@ h1 {
   margin: 0;
 }
 
+h2 {
+  font-size: 14px;
+  margin: 0 0 6px;
+}
+
 label {
   display: grid;
   gap: 6px;
@@ -68,4 +73,32 @@ button:disabled {
 .status {
   font-size: 12px;
   min-height: 16px;
+}
+
+.manual {
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  padding-top: 10px;
+  display: grid;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.manual ol {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+}
+
+.manual kbd {
+  background: rgba(15, 23, 42, 0.8);
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  font-size: 11px;
+}
+
+.manual .tip {
+  margin: 0;
+  color: #94a3b8;
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -25,6 +25,16 @@
         <a href="#" id="manageLink">Manage tables</a>
       </section>
       <p class="status" id="status"></p>
+      <section class="manual">
+        <h2>Manual</h2>
+        <ol>
+          <li>Open a data table on any website and press <kbd>Alt</kbd> while clicking a cell to capture it.</li>
+          <li>Give the column a name, then save it to the selected output table.</li>
+          <li>Repeat on other pages to map additional columns. Each saved column remembers its source URL.</li>
+          <li>Return here, enter the dates you need, and export the assembled CSV.</li>
+        </ol>
+        <p class="tip">Need to adjust mappings? Use the “Manage tables” link to review selectors and URLs.</p>
+      </section>
     </main>
     <script src="popup.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- add a usage manual section to the popup for quick onboarding
- store the source URL for each mapped column and surface it in the overlay/options
- enhance the overlay with source previews, hover annotations, and hide selection styling when collapsed

## Testing
- not run (browser extension)

------
https://chatgpt.com/codex/tasks/task_e_68e3849e23d88326a519120a3c01f425